### PR TITLE
Update ncipollo/release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,10 @@ jobs:
           fi
 
       - name: "Release versioned"
-        # v1.10.0
-        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37
+        # v1.11.1
+        uses: ncipollo/release-action@4c75f0f2e4ae5f3c807cf0904605408e319dcaac
         with:
           allowUpdates: true
+          generateReleaseNotes: true
           artifacts: "r10e-build/*"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use `v.11.1`. Pin the commit hash, which is less malleable than tag. Also set "generateReleaseNotes" to true.