### PR TITLE
Support optional data directories in JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,18 @@ Here's an example: [config.json](./config.json)
       "src": "build/r10edocker-darwin-arm64",
       "dest": "/app/r10edocker-darwin-arm64"
     }
+  ],
+  "extern_data": [
+    {
+      "src": "LICENSE",
+      "dest": "/LICENSE"
+    }
   ]
 }
 ```
 
-Fields "project_name", "build_cmd", and "artifacts" are mandatory. Field
-"maintainers" is optional.
+Fields "project_name", "build_cmd", and "artifacts" are mandatory. Fields
+"maintainers" and "extern_data" are optional.
 
 | Name         | Value Type | Can be null or empty |
 | :---         | :---       | :---:                |
@@ -96,6 +102,7 @@ Fields "project_name", "build_cmd", and "artifacts" are mandatory. Field
 | build_cmd    | string     | false                |
 | maintainers  | array of strings | true           |
 | artifacts    | array of objects | false          |
+| extern_data  | array of objects | true           |
 
 - "project_name" is a name to identify your project. Your reproducible container
   image will be named after it. Please make sure there's no whitespace
@@ -104,12 +111,17 @@ Fields "project_name", "build_cmd", and "artifacts" are mandatory. Field
   a shell script file for it
 - "artifacts" contains information about the source and destination path
   information for the Go executable(s) to get into the container image
-  - "src" shall be a *relative path* of the executable (built with "build_cmd"
-    on a build host) with respect to the project's directory root
-  - "dest" shall be an *absolute path* of the executable in the final Docker
-    container image
+  - "src" shall be a *relative path* of the executable file (built with
+    "build_cmd" on a build host) with respect to the project's directory root
+  - "dest" shall be an *absolute path* of the executable file in the final
+    Docker container image
 - "maintainer" contains a list of project maintainer
-names/aliases/GitHub handles
+  names/aliases/GitHub handles
+- "extern_data" contains information about the source and destination path
+  information for data external to the Go executable(s) to get into the
+  container. Unlike in "artifacts", the external data path can be either a file
+  or a directory. However, the source and destination paths for the same
+  external datum must be of the same type (file or directory) when instantiated.
 
 #### Generate r10e build scripts, and build
 

--- a/config.json
+++ b/config.json
@@ -19,5 +19,11 @@
       "src": "build/r10edocker-darwin-arm64",
       "dest": "/app/r10edocker-darwin-arm64"
     }
+  ],
+  "extern_data": [
+    {
+      "src": "LICENSE",
+      "dest": "/LICENSE"
+    }
   ]
 }

--- a/pkg/r10e-docker/files/Dockerfile
+++ b/pkg/r10e-docker/files/Dockerfile
@@ -31,11 +31,13 @@ COPY . "/build/${PROJECT_NAME}"
 
 RUN cd "/build/${PROJECT_NAME}" && \
     {{range $index, $x := .Artifacts}}mkdir -p /archive/$(dirname {{$x.Destination}}) && \
+    {{end}}{{range $index, $x := .ExternalData}}mkdir -p /archive/$(dirname {{$x.Destination}}) && \
     {{end}}nix-shell -p go_1_19 gnumake \
       --run "go version && \
              {{.BuildCmd}}" && \
     sha256sum {{range $index, $x := .Artifacts}}/build/${PROJECT_NAME}/{{$x.Source}} {{end}} && \
     {{range $index, $x := .Artifacts}}cp /build/${PROJECT_NAME}/{{$x.Source}} /archive/{{$x.Destination}} && \
+    {{end}}{{range $index, $x := .ExternalData}}cp -r /build/${PROJECT_NAME}/{{$x.Source}} /archive/{{$x.Destination}} && \
     {{end}}cd /archive && \
     tar cvz --sort=name --mtime="2000-01-02 00:00:00" -f "${PROJECT_NAME}.tar.gz" *
 

--- a/pkg/r10e-docker/files/pkgs/myapp/default.nix
+++ b/pkg/r10e-docker/files/pkgs/myapp/default.nix
@@ -28,8 +28,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     echo "{{.ProjectName}}: $out"
     mkdir -p $out
-    cp --parents {{range $index, $x := .Artifacts}}./{{$x.Destination}} {{end}} $out/
-  '';
+    cp --parents {{range $index, $x := .Artifacts}} ./{{$x.Destination}}{{end}} $out/
+    cp -r --parents {{range $index, $x := .ExternalData}} ./{{$x.Destination}}{{end}} $out/
+    '';
 
   meta = with lib; {
     description = "{{.ProjectName}} 1.0.0";

--- a/pkg/r10e-docker/r10edocker.go
+++ b/pkg/r10e-docker/r10edocker.go
@@ -15,16 +15,19 @@ import (
 )
 
 type Config struct {
-	ProjectName string     `json:"project_name"`
-	BuildCmd    string     `json:"build_cmd"`
-	Maintainers []string   `json:"maintainers"`
-	Artifacts   []Artifact `json:"artifacts"`
+	ProjectName  string          `json:"project_name"`
+	BuildCmd     string          `json:"build_cmd"`
+	Maintainers  []string        `json:"maintainers"`
+	Artifacts    []Artifact      `json:"artifacts"`
+	ExternalData []ExternalDatum `json:"extern_data"`
 }
 
 type Artifact struct {
 	Source      string `json:"src"`
 	Destination string `json:"dest"`
 }
+
+type ExternalDatum = Artifact
 
 var (
 	//go:embed files
@@ -76,6 +79,15 @@ func ReadConfigFile(configFilePath string) (config Config, error error) {
 				"neither src nor dest of artifact shall be empty or null; got %#v", a)
 		}
 	}
+
+	for _, d := range config.ExternalData {
+		if strings.TrimSpace(d.Source) == "" ||
+			strings.TrimSpace(d.Destination) == "" {
+			return config, fmt.Errorf(
+				"neither src nor dest of extern_datum shall be empty or null; got %#v", d)
+		}
+	}
+
 	return config, nil
 }
 

--- a/scripts/container_cp.sh
+++ b/scripts/container_cp.sh
@@ -39,7 +39,7 @@ do_extract() {
   local sum
 
   container_id=$(docker create "$image" --entrypoint="null")
-  docker cp "$container_id:$from" "$to"
+  docker cp -L "$container_id:$from" "$to"
   docker rm "$container_id" >/dev/null
 
   echo "Successfully copied $from in container $image to $to"


### PR DESCRIPTION
This allows external data, e.g., certificates and software license files, not embedded in Go binaries to be copied into the final, reproducible Docker image.