### PR TITLE
Make r10edocker version more easily set

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,4 @@ r10e-docker/out/
 build/
 r10e-build/
 .github/
-.git/
 CODEOWNERS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           cd ${{ github.workspace }}
           APP_VERSION="$(r10e-build/r10edocker-linux-amd64 --version | rev | cut -f1 -d' ' | rev)"
           if [ "$APP_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "version (${APP_VERSION}) in version/version.go and tagged version (${RELEASE_VERSION}) mismatch"
+            echo "This is not supposed to happen. There must be a versioning bug."
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build_dir := $(mkfile_dir)/build
 r10e_build_dir := $(mkfile_dir)/r10e-build
 GOOS ?= $(shell go version | awk '{print $$NF}' | cut -d/ -f1)
 GOARCH ?= $(shell go version | awk '{print $$NF}' | cut -d/ -f2)
+VERSION ?= $(shell git describe --tags --dirty  --always)
 bin := $(build_dir)/r10edocker-$(GOOS)-$(GOARCH)
 # project_name must match that in config.json
 project_name := go-r10e-docker
@@ -15,7 +16,7 @@ all: build
 
 build:
 	mkdir -p $(build_dir)
-	CGO_ENABLED=0 go build -trimpath -o $(bin) $(mkfile_dir)
+	CGO_ENABLED=0 go build -trimpath -ldflags "-X main.version=$(VERSION)" -o $(bin) $(mkfile_dir)
 
 r10e-build: build
 	cp $(bin) $(build_dir)/r10edocker

--- a/cmd/r10e-docker/root.go
+++ b/cmd/r10e-docker/root.go
@@ -7,15 +7,13 @@ import (
 
 	"github.com/spf13/cobra"
 	r10edocker "github.com/syncom/r10edocker/pkg/r10e-docker"
-	"github.com/syncom/r10edocker/version"
 )
 
 var configFile string
 
 var rootCmd = &cobra.Command{
-	Use:     "r10edocker",
-	Version: version.Version,
-	Short:   "r10edocer - make minimum, reproducible Docker container for Go application",
+	Use:   "r10edocker",
+	Short: "r10edocer - make minimum, reproducible Docker container for Go application",
 	Long: `r10edocker creates a framework for making reproducible Docker container images
 
 Configure r10edocker in JSON.
@@ -34,7 +32,8 @@ The resulting Docker container is minimum, in that it contains only the applicat
 	},
 }
 
-func Execute() {
+func Execute(version string) {
+	rootCmd.Version = version
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("CLI error:, '%s'", err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	r10edocker "github.com/syncom/r10edocker/cmd/r10e-docker"
 )
 
+var version = "development"
+
 func main() {
-	r10edocker.Execute()
+	r10edocker.Execute(version)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,0 @@
-package version
-
-const Version = "0.2.0"


### PR DESCRIPTION
We make the version of `r10edocker` more easily overridable during build, which reduces the amount of error-prone manual work to allow better automation.