### PR TITLE
Make source repo in Docker builder non-dirty

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
 r10e-docker/out/
 build/
 r10e-build/
-.github/
-CODEOWNERS

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.bak
-build/
-r10e-docker/out/
 .DS_Store
+# Don't remove below. Necessary for proper versioning in CI release
+build/
+r10e-docker/
+!pkg/r10e-docker/


### PR DESCRIPTION
- gitignore r10e-docker/ dir, and unignore pkg/r10e-docker/ dir

  This is for correct version string in r10e-build, so that the docker build will not be treated as dirty.

- Copy all source files to avoid the dirty status

  Copy `CODEONWERS` and `.gitignore` to avoid git `describe --dirty` getting dirty.