### PR TITLE
Fix release version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           set -euxo pipefail
           cd ${{ github.workspace }}
           APP_VERSION="$(r10e-build/r10edocker-linux-amd64 --version | rev | cut -f1 -d' ' | rev)"
-          if [ "$APP_VERSION" != "$RELEASE_VERSION" ]; then
+          if [ "$APP_VERSION" != "v$RELEASE_VERSION" ]; then
             echo "This is not supposed to happen. There must be a versioning bug."
             exit 1
           fi


### PR DESCRIPTION
Fix a bug in release version check: Need to prefix character `v` to `$RELEASE_VERSION`.