### PR TITLE
GHA: release canary builds

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,29 @@
+name: "Reproducible (r10e) r10edocker binaries canary builds"
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  release-r10e-binaries:
+    name: "Release r10e r10edocker"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+
+      - name: "Build r10e apps at HEAD of default branch"
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}
+          make r10e-build
+
+      - name: "Release versioned"
+        # v1.11.1
+        uses: ncipollo/release-action@4c75f0f2e4ae5f3c807cf0904605408e319dcaac
+        with:
+          tag: "canary"
+          name: "Canary"
+          allowUpdates: true
+          generateReleaseNotes: false
+          artifacts: "r10e-build/*"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ If your Go application is not reproducible, make sure you
 ### install `r10edocker`
 
 ```bash
-go install github.com/syncom/r10edocker@latest
+# commit SHA for v0.2.1. Pin commit because it's less malleable than a tag
+go install github.com/syncom/r10edocker@b2456e371147ed61d8f6d29f31b96a7be55cc207
 ```
 
 ### Set up your Go project for reproducible Docker builds


### PR DESCRIPTION
A canary build contains artifacts built from the HEAD of the default branch (`main`).

Add a GitHub Actions workflow to release canary builds to GitHub Releases.