### PR TITLE
Fetch all history for all tags

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -19,6 +19,8 @@ jobs:
           set -euxo pipefail
           cd ${{ github.workspace }}
           make r10e-build
+          # for debugging
+          ./r10e-build/r10edocker-linux-amd64 --version
 
       - name: "Release versioned"
         # v1.11.1

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3
+        with:
+          # Fetch all history for all tags and branches
+          fetch-depth: 0
 
       - name: "Build r10e apps at HEAD of default branch"
         run: |

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,6 +23,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: "checkout code"
         uses: actions/checkout@v3
+        with:
+          # Fetch all history for all tags and branches
+          fetch-depth: 0
       - name: "build r10edocker"
         run: |
           set -euxo pipefail


### PR DESCRIPTION
In `canary.yml`, fetch all commit history for tags. Unfortunately, there's no easy way to make canary artifacts display a fixed "canary" version string, due to the way we set `VERSION` value in Makefile. But this should be OK as long as the canary builds are reproducible.