### PR TITLE
Use realpath command for prettier path values

### DIFF
--- a/pkg/r10e-docker/files/build_container.sh
+++ b/pkg/r10e-docker/files/build_container.sh
@@ -5,7 +5,8 @@ set -euxo pipefail
 SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 OUT_DIR="${SCRIPT_DIR}/out"
 OUT_TARBALL_NAME="{{.ProjectName}}-latest.tar.gz"
-REVISION=$(git --work-tree="${SCRIPT_DIR}"/../ --git-dir="${SCRIPT_DIR}"/../.git \
+REVISION=$(git --work-tree="$(realpath "${SCRIPT_DIR}"/../)" \
+  --git-dir="$(realpath "${SCRIPT_DIR}"/../.git)" \
   rev-parse HEAD)
 BUILDER_TAG_NAME="{{.ProjectName}}-builder:$REVISION"
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 
 SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 readonly SCRIPT_DIR
-PROJECT_DIR="${SCRIPT_DIR}/.."
+PROJECT_DIR="$(realpath "${SCRIPT_DIR}/..")"
 readonly PROJECT_DIR
 
 cd "$PROJECT_DIR"

--- a/scripts/test_configs.sh
+++ b/scripts/test_configs.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 
 SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 readonly SCRIPT_DIR
-PROJECT_DIR="${SCRIPT_DIR}/.."
+PROJECT_DIR="$(realpath "${SCRIPT_DIR}/..")"
 readonly PROJECT_DIR
 PROJECT_NAME="go-r10e-docker"
 readonly PROJECT_NAME


### PR DESCRIPTION
This is a cosmetic improvement.  We use the `realpath` command in coreutils to get prettier file paths in shell scripts.