### PR TITLE
Release gzipped binaries to GitHub

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -20,7 +20,9 @@ jobs:
           cd ${{ github.workspace }}
           make r10e-build
           # for debugging
-          ./r10e-build/r10edocker-linux-amd64 --version
+          gunzip -c ./r10e-build/r10edocker-linux-amd64.gz >r10edocker.tmp
+          chmod +x r10edocker.tmp
+          ./r10edocker.tmp --version
 
       - name: "Release canary binaries"
         # v1.11.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
         run: |
           set -euxo pipefail
           cd ${{ github.workspace }}
-          APP_VERSION="$(r10e-build/r10edocker-linux-amd64 --version | rev | cut -f1 -d' ' | rev)"
+          gunzip -c ./r10e-build/r10edocker-linux-amd64.gz >r10edocker.tmp
+          chmod +x r10edocker.tmp
+          APP_VERSION="$(./r10edocker.tmp --version | rev | cut -f1 -d' ' | rev)"
           if [ "$APP_VERSION" != "v$RELEASE_VERSION" ]; then
             echo "This is not supposed to happen. There must be a versioning bug."
             exit 1

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ r10e-build: build
 	$(mkfile_dir)/scripts/container_cp.sh "$(project_name):latest" \
 	  "/app/r10edocker-darwin-arm64" "$(r10e_build_dir)/r10edocker-darwin-arm64"
 	cd $(r10e_build_dir) && sha256sum r10edocker-* | sort -k2 > sha256sums.r10e.txt
+	gzip -9 $(r10e_build_dir)/r10edocker-*
 
 clean:
 	rm -rf $(build_dir)


### PR DESCRIPTION
We gzip reproducible binaries before publishing them to GitHub releases. It has two advantages compared to releasing executables directly

- The artifact sizes are smaller
- It's less likely to get the binaries flagged as malware, e.g., by Gatekeeper on macOS, when they are gunzipped