### PR TITLE
Use version.go file for app versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           gunzip -c ./r10e-build/r10edocker-linux-amd64.gz >r10edocker.tmp
           chmod +x r10edocker.tmp
           APP_VERSION="$(./r10edocker.tmp --version | rev | cut -f1 -d' ' | rev)"
-          if [ "$APP_VERSION" != "v$RELEASE_VERSION" ]; then
-            echo "This is not supposed to happen. There must be a versioning bug."
+          if [ "$APP_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "error: app version must equal tagged release version"
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ build_dir := $(mkfile_dir)/build
 r10e_build_dir := $(mkfile_dir)/r10e-build
 GOOS ?= $(shell go version | awk '{print $$NF}' | cut -d/ -f1)
 GOARCH ?= $(shell go version | awk '{print $$NF}' | cut -d/ -f2)
-VERSION ?= $(shell git describe --tags --dirty  --always)
 bin := $(build_dir)/r10edocker-$(GOOS)-$(GOARCH)
 # project_name must match that in config.json
 project_name := go-r10e-docker
@@ -16,7 +15,11 @@ all: build
 
 build:
 	mkdir -p $(build_dir)
-	CGO_ENABLED=0 go build -trimpath -ldflags "-X main.version=$(VERSION)" -o $(bin) $(mkfile_dir)
+ifndef VERSION
+	CGO_ENABLED=0 go build -trimpath -o $(bin) $(mkfile_dir)
+else
+	CGO_ENABLED=0 go build -trimpath -ldflags "-X main.ver=$(VERSION)" -o $(bin) $(mkfile_dir)
+endif
 
 r10e-build: build
 	cp $(bin) $(build_dir)/r10edocker

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# r10edocker: Reproducible Docker Container for Go Application
+# r10edocker: Reproducible Docker Container for Go Applications
 
 [![sanity checks](https://github.com/syncom/r10edocker/actions/workflows/sanity.yml/badge.svg)](https://github.com/syncom/r10edocker/actions/workflows/sanity.yml)
 

--- a/main.go
+++ b/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	r10edocker "github.com/syncom/r10edocker/cmd/r10e-docker"
+	"github.com/syncom/r10edocker/version"
 )
 
-var version = "development"
+var ver = version.Version
 
 func main() {
-	r10edocker.Execute(version)
+	r10edocker.Execute(ver)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Version = "0.3.0"


### PR DESCRIPTION
This is to make it easier to test the reproducible executables before tagging a release - we can use a canary executable for QA testing.

Also made some minor README updates.

Bump version to 0.3.0