### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.3.0"
+const Version = "0.3.1"


### PR DESCRIPTION
This is to upgrade to a newer nixpkgs version 23.11, shipped with go1.21.4, in build template.