### PR TITLE
README.md: Update `go install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If your Go application is not reproducible, make sure you
 ### install `r10edocker`
 
 ```bash
-# commit SHA for v0.2.1. Pin commit because it's less malleable than a tag
-go install github.com/syncom/r10edocker@b2456e371147ed61d8f6d29f31b96a7be55cc207
+# commit SHA for v0.3.1. Pin commit because it's less malleable than a tag
+go install github.com/syncom/r10edocker@281bcd206ed09a11765822dcf6a50e3deaf3bd4c
 ```
 
 ### Set up your Go project for reproducible Docker builds


### PR DESCRIPTION
Use the Git commit for tag v0.3.1 in `go install`, in README.md.