### PR TITLE
GHA: update dependencies

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,8 +25,8 @@ jobs:
           ./r10edocker.tmp --version
 
       - name: "Release canary binaries"
-        # v1.11.1
-        uses: ncipollo/release-action@4c75f0f2e4ae5f3c807cf0904605408e319dcaac
+        # v1.14.0
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         with:
           tag: "canary"
           name: "Canary"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
           fi
 
       - name: "Release versioned"
-        # v1.11.1
-        uses: ncipollo/release-action@4c75f0f2e4ae5f3c807cf0904605408e319dcaac
+        # v1.14.0
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         with:
           allowUpdates: true
           generateReleaseNotes: true

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@v5.0.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
       - name: "checkout code"
         uses: actions/checkout@v4.1.1
         with:
@@ -102,6 +103,7 @@ jobs:
         uses: actions/setup-go@v5.0.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
       - name: "checkout code"
         uses: actions/checkout@v4.1.1
       - name: "test JSON config files"


### PR DESCRIPTION
Bump ncipollo/release-action to v1.14.0. Use commit SHA as revision instead of tag, because the former is less mutable.