### PR TITLE
Update to go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syncom/r10edocker
 
-go 1.19
+go 1.21
 
 require github.com/spf13/cobra v1.5.0
 


### PR DESCRIPTION
Use minimum version go 1.21 in `go.mod`, to move away from the to-be-deprecated go 1.19.