### PR TITLE
Minor fix: use capitalized Dockerfile keyword

### DIFF
--- a/pkg/r10e-docker/files/Dockerfile
+++ b/pkg/r10e-docker/files/Dockerfile
@@ -1,5 +1,5 @@
 # The following information is from https://hub.docker.com/r/nixos/nix/tags
-FROM nixos/nix:2.20.1@sha256:bbd436fac4b50712fb065c3cb1d74702aa9d731cc6cc702dbba20a9ccb2d8769 as image_builder
+FROM nixos/nix:2.20.1@sha256:bbd436fac4b50712fb065c3cb1d74702aa9d731cc6cc702dbba20a9ccb2d8769 AS image_builder
 
 #########################################################
 # Step 1: Prepare nixpkgs for reproducible (r10e) builds


### PR DESCRIPTION
This is a minor improvement.