### PR TITLE
Provide config option to include cacert

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,22 @@ Here's an example: [config.json](./config.json)
       "src": "LICENSE",
       "dest": "/LICENSE"
     }
-  ]
+  ],
+  "include_ca_bundle": true
 }
 ```
 
 Fields "project_name", "build_cmd", and "artifacts" are mandatory. Fields
 "maintainers" and "extern_data" are optional.
 
-| Name         | Value Type | Can be null or empty |
-| :---         | :---       | :---:                |
-| project_name | string     | false                |
-| build_cmd    | string     | false                |
-| maintainers  | array of strings | true           |
-| artifacts    | array of objects | false          |
-| extern_data  | array of objects | true           |
+| Name              | Value Type | Can be null or empty |
+| :---              | :---       | :---:                |
+| project_name      | string     | false                |
+| build_cmd         | string     | false                |
+| maintainers       | array of strings | true           |
+| artifacts         | array of objects | false          |
+| extern_data       | array of objects | true           |
+| include_ca_bundle | boolean    | true                 |
 
 - "project_name" is a name to identify your project. Your reproducible container
   image will be named after it. Please make sure there's no whitespace
@@ -123,6 +125,13 @@ Fields "project_name", "build_cmd", and "artifacts" are mandatory. Fields
   container. Unlike in "artifacts", the external data path can be either a file
   or a directory. However, the source and destination paths for the same
   external datum must be of the same type (file or directory) when instantiated.
+- "include_ca_bundle" dictates a root CA bundle from the `cacert` package of
+  nixpkgs will be installed in the container image. If the value of this field
+  is set to `true` the root CA bundle will be included in the container, which
+  is useful and possibly necessary if your application uses TLS and the
+  system-wide trusted CA store; otherwise if this field is set to `false` or
+  absent from the configuration file, no root CA bundle will be installed in the
+  container.
 
 #### Generate r10e build scripts, and build
 

--- a/config.json
+++ b/config.json
@@ -25,5 +25,6 @@
       "src": "LICENSE",
       "dest": "/LICENSE"
     }
-  ]
+  ],
+  "include_ca_bundle": true
 }

--- a/pkg/r10e-docker/files/docker.nix
+++ b/pkg/r10e-docker/files/docker.nix
@@ -8,7 +8,11 @@ pkgs.dockerTools.buildImage {
   copyToRoot = pkgs.buildEnv {
     name = "{{.ProjectName}}";
     pathsToLink = [ "/" ];
+    {{if .IncludeCABundle }}
+    paths = with pkgs; [cacert (import ./custom_configuration.nix {}).{{.ProjectName}}];
+    {{ else }}
     paths = with pkgs; [(import ./custom_configuration.nix {}).{{.ProjectName}}];
+    {{end}}
   };
   config = {
     Cmd = [];

--- a/pkg/r10e-docker/r10edocker.go
+++ b/pkg/r10e-docker/r10edocker.go
@@ -15,11 +15,12 @@ import (
 )
 
 type Config struct {
-	ProjectName  string          `json:"project_name"`
-	BuildCmd     string          `json:"build_cmd"`
-	Maintainers  []string        `json:"maintainers"`
-	Artifacts    []Artifact      `json:"artifacts"`
-	ExternalData []ExternalDatum `json:"extern_data"`
+	ProjectName     string          `json:"project_name"`
+	BuildCmd        string          `json:"build_cmd"`
+	Maintainers     []string        `json:"maintainers"`
+	Artifacts       []Artifact      `json:"artifacts"`
+	ExternalData    []ExternalDatum `json:"extern_data"`
+	IncludeCABundle bool            `json:"include_ca_bundle"`
 }
 
 type Artifact struct {
@@ -102,7 +103,7 @@ func GenR10eDocker(config *Config) error {
 		if err != nil {
 			return err
 		}
-		//log.Printf("Visited: %s\n", path)
+
 		if !d.IsDir() {
 			template, err := template.ParseFS(templateFs, path)
 			if err != nil {

--- a/scripts/test_configs.sh
+++ b/scripts/test_configs.sh
@@ -27,3 +27,7 @@ make clean && \
   make r10e-build config_file="${PROJECT_DIR}/testdata/config2_with-extern-data.json" project_name="${PROJECT_NAME}" && \
   docker load -i "${PROJECT_DIR}/r10e-docker/out/${PROJECT_NAME}-latest.tar.gz"
   "${SCRIPT_DIR}/container_cp.sh" "${PROJECT_NAME}:latest" /x/y/d.txt "${TMP_FILE}"
+
+make clean && \
+  rm -rf r10e-docker && \
+  make r10e-build config_file="${PROJECT_DIR}/testdata/config3_include-ca-bundle-false.json" project_name="${PROJECT_NAME}"

--- a/testdata/config3_include-ca-bundle-false.json
+++ b/testdata/config3_include-ca-bundle-false.json
@@ -1,0 +1,23 @@
+{
+  "project_name": "go-r10e-docker",
+  "build_cmd": "scripts/build-all.sh",
+  "artifacts": [
+    {
+      "src": "build/r10edocker-linux-amd64",
+      "dest": "/app/r10edocker-linux-amd64"
+    },
+    {
+      "src": "build/r10edocker-linux-arm64",
+      "dest": "/app/r10edocker-linux-arm64"
+    },
+    {
+      "src": "build/r10edocker-darwin-amd64",
+      "dest": "/app/r10edocker-darwin-amd64"
+    },
+    {
+      "src": "build/r10edocker-darwin-arm64",
+      "dest": "/app/r10edocker-darwin-arm64"
+    }
+  ],
+  "include_ca_bundle": false
+}


### PR DESCRIPTION
We provide a new `include_ca_bundle` option in r10edocker's configuration file to determine if a root CA bundle will be included in the generated Docker container image or not. The CA bundle is usually necessary if the contained application uses TLS.

We also update documentation and the sample "config.json" file to show case this new option.