### PR TITLE
Use 1.19 for go directive in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syncom/r10edocker
 
-go 1.23.3
+go 1.19
 
 require github.com/spf13/cobra v1.5.0
 


### PR DESCRIPTION
Because the code is 1.19 compatible, we decrease the specified minimum version for better compatibility.