### PR TITLE
Improve documentation and debugging info

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ optional.
   container. Unlike in "artifacts", the external data path can be either a file
   or a directory. However, the source and destination paths for the same
   external datum must be of the same type (file or directory) when instantiated.
+  - "src" shall be a *relative path* to the project diectory where `r10edocker`
+    is run
+  - "dest" shall be an *absolut path* in the final Docker container image
 - "include_ca_bundle" dictates a root CA bundle from the `cacert` package of
   nixpkgs will be installed in the container image. If the value of this field
   is set to `true` the root CA bundle will be included in the container, which

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ optional.
   external datum must be of the same type (file or directory) when instantiated.
   - "src" shall be a *relative path* to the project diectory where `r10edocker`
     is run
-  - "dest" shall be an *absolut path* in the final Docker container image
+  - "dest" shall be an *absolute path* in the final Docker container image
 - "include_ca_bundle" dictates a root CA bundle from the `cacert` package of
   nixpkgs will be installed in the container image. If the value of this field
   is set to `true` the root CA bundle will be included in the container, which

--- a/pkg/r10e-docker/files/Makefile
+++ b/pkg/r10e-docker/files/Makefile
@@ -6,7 +6,7 @@ all: r10e-docker
 
 .PHONY: r10e-docker
 r10e-docker:
-	$(mkfile_dir)/build_container.sh 2>/dev/null
+	$(mkfile_dir)/build_container.sh
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Update README.md to provide more information about `extern_data`.

Do not redirect stderr to `/dev/null` in `build_container.sh` to make debuggin in CI easier. Note that the caller of this script can still do the redirect at will.